### PR TITLE
Some enhancements about the repositories. Enables usage for ARM64 including Rasberry Pie‘s

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,11 +40,13 @@ galera_server_bind_address: "{{ openstack_service_bind_address | default('0.0.0.
 galera_debconf_items: []
 galera_mariadb_service_name: mariadb
 galera_mariadb_server_package: "{{ _galera_mariadb_server_package }}"
+galera_mariadb_client_package: "{{ _galera_mariadb_client_package }}"
+
 
 # The major version used to select the repo URL path
 # NOTE(noonedeadpunk) 10.4.13 seems broken, as it crushed during requests http://paste.openstack.org/show/794059/
 galera_major_version: 10.4
-galera_minor_version: 12
+galera_minor_version: 14
 
 # Set the URL for the MariaDB repository
 galera_repo_host: "downloads.mariadb.com"

--- a/vars/ubuntu-20.04.yml
+++ b/vars/ubuntu-20.04.yml
@@ -74,7 +74,7 @@ galera_debconf_items:
     vtype: "string"
 
 # Repositories
-_galera_repo_url: "http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.4/ubuntu"
+_galera_repo_url: "http://{{ galera_repo_host }}/MariaDB/mariadb-{{ galera_major_version }}.{{ galera_minor_version }}/repo/{{ ansible_distribution | lower }}"
 _galera_repo:
   repo: "deb [arch=amd64,arm64,ppc64el] {{ galera_repo_url }} {{ ansible_distribution_release }} main"
   state: "present"

--- a/vars/ubuntu-20.04.yml
+++ b/vars/ubuntu-20.04.yml
@@ -21,7 +21,7 @@ _galera_disable_privatedevices: yes
 
 # Galera GPG Keys
 _galera_gpg_keys:
-  - url: http://repo.vexxhost.net/mariadb/key.gpg
+  - url: https://mariadb.org/mariadb_release_signing_key.asc
 
 galera_server_required_distro_packages:
   - apt-transport-https
@@ -43,14 +43,15 @@ galera_var_run_socket: "/var/run/mysqld/mysqld.sock"
 # so that it can be used in debconf later in the
 # "galera_common" role.
 _galera_mariadb_server_package: "mariadb-server-{{ galera_major_version }}"
+_galera_mariadb_client_package: "mariadb-client-{{ galera_major_version }}"
 
 # NB This is specifically galera_server_mariadb_distro_packages as these
 # packages only get installed during the galera play - this is because of
 # the preseed task and the service startup control used when installing
 # mariadb-galera-server and galera.
 galera_server_mariadb_distro_packages:
-  - libmariadb-dev
-  - mariadb-client
+  - libmariadb3
+  - "{{ galera_mariadb_server_package }}"
   - mariadb-backup
   - "{{ galera_mariadb_server_package }}"
   - galera-4
@@ -73,9 +74,9 @@ galera_debconf_items:
     vtype: "string"
 
 # Repositories
-_galera_repo_url: "http://repo.vexxhost.net/mariadb"
+_galera_repo_url: "http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.4/ubuntu"
 _galera_repo:
-  repo: "deb {{ galera_repo_url }} {{ ansible_distribution_release }} main"
+  repo: "deb [arch=amd64,arm64,ppc64el] {{ galera_repo_url }} {{ ansible_distribution_release }} main"
   state: "present"
   filename: "MariaDB"
 

--- a/vars/ubuntu-20.04.yml
+++ b/vars/ubuntu-20.04.yml
@@ -51,7 +51,7 @@ _galera_mariadb_client_package: "mariadb-client-{{ galera_major_version }}"
 # mariadb-galera-server and galera.
 galera_server_mariadb_distro_packages:
   - libmariadb3
-  - "{{ galera_mariadb_server_package }}"
+  - "{{ galera_mariadb_client_package }}"
   - mariadb-backup
   - "{{ galera_mariadb_server_package }}"
   - galera-4


### PR DESCRIPTION
This are some enhancements mostly focused on Ubuntu 20.04.
 * switching back to the original mariadb repo
 * bring back the support for ARM64 including Raspberry Pie Hardware. Because the are cheap for labs and test beds

Funny example with Raspberry Pi 3 three nodes to serve for a small testbed around 10 hosts and explore the new functions inside Ussuri 

```yaml
---
- name: Install Galera server
  hosts: galera
  become: true
  vars:
    galera_install_server: true
    galera_install_client: true
    galera_root_password: *topsecret*
    galera_innodb_log_file_size: 64M
    galera_innodb_buffer_pool_size: 512M
    galera_innodb_log_buffer_size: 16M
    galera_max_heap_table_size: 8M
    galera_tmp_table_size: 8M
    galera_gcache_size: 128M
    galera_cluster_members: "{{ groups['galera'] }}"
    galera_cluster_name: imperium_alpha

  pre_tasks:

    - set_fact:
        galera_server_bootstrap_node: "{{ item }}"
      with_random_choice: "{{ groups['galera'] }}"
      run_once: true

    # if your inventory is defined with FQDN`s instead IP Addresses
    - set_fact:
        ansible_host: "{{ ansible_default_ipv4['address'] }}"

  roles:
    - role_openstack-ansible-galera_server
```